### PR TITLE
Markdown and Layout fix ups

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ author:
   name: Aman Jilani
   email: akjuni@outlook.com
 description: > # this means to ignore newlines until "show_excerpts:"
- AWESOME DESCRIPTION
+ Commentary on Science and Technology
 
 show_excerpts: false # set to true to show excerpts on the homepage
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,6 +27,8 @@ layout: default
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">
+    <p><em>{{ post.description }}</em></p>
+    <hr>
     {{ content }}
   </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,7 +27,7 @@ layout: default
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">
-    <p><em>{{ post.description }}</em></p>
+    <p><em>{{ page.description }}</em></p>
     <hr>
     {{ content }}
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,7 +27,8 @@ layout: default
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">
-    <p><em>{{ page.description }}</em></p>
+    <div class="post-description"> {{ page.description | markdownify }} </div>
+   
     <hr>
     {{ content }}
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,7 +27,7 @@ layout: default
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">
-    <div class="post-description"> {{ page.description | markdownify }} </div>
+    <div class="description"> {{ page.description | markdownify }} </div>
    
     <hr>
     {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,7 +27,7 @@ layout: default
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">
-    <div class="description"> {{ page.description | markdownify }} </div>
+    <div class="post-description"> {{ page.description | markdownify }} </div>
    
     <hr>
     {{ content }}

--- a/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
+++ b/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Potential For Agronomic Improvement In Orphan Crops
-description: News and Views article written about a paper by *Scheben et al.*
+description: News and Views article written about a paper by Scheben et al. 
 ---
 
 # Of orphan crops and groundcherries  

--- a/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
+++ b/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Potential For Agronomic Improvement In Orphan Crops
-description: News and Views article written about a paper by Scheben et al.
+description: News and Views article written about [^1]
 ---
 
 # Of orphan crops and groundcherries  

--- a/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
+++ b/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
@@ -1,50 +1,50 @@
 ---
 layout: post
 title: Potential For Agronomic Improvement In Orphan Crops
-description: News and Views article written about [^1]
+description: News and Views article written about a paper by Scheben et al.
 ---
 
 # Of orphan crops and groundcherries  
 
 ## What are orphan crops?
 
-While gene editing technologies have been used to greatly improve staple crops such as corn, wheat, and rice [^2], there exist minor, regionally important but globally unknown crops whose potential for genetic improvement has not yet been fully explored. These “orphan crops” suffer from a range of agronomic issues that make them unsuitable for large scale production [^3]
+While gene editing technologies have been used to greatly improve staple crops such as corn, wheat, and rice[^2], there exist minor, regionally important but globally unknown crops whose potential for genetic improvement has not yet been fully explored. These “orphan crops” suffer from a range of agronomic issues that make them unsuitable for large scale production[^3]
 
-This paper showcases the improvements made to the agronomic potential of the orphan crop – *Physalis pruinos*  ~~(groundcherry)~~ – via the genomic editing technology, CRISPR Cas-9 ~~((Clustered regularly interspaced short palindromic repeats) (CRISPR associated protein-9 nuclease) CC9) ~~. Specifically targeting its sprawling growth habit and very strong stem abscission via orthologs ~~(genes that are the same but are present in different species)~~ of domestication genes in tomatoes.  
+This paper showcases the improvements made to the agronomic potential of the orphan crop – *Physalis pruinos*  ~~(groundcherry)~~ – via the genomic editing technology, CRISPR Cas-9 ~~((Clustered regularly interspaced short palindromic repeats) (CRISPR associated protein-9 nuclease) CC9)~~. Specifically targeting its sprawling growth habit and very strong stem abscission via orthologs ~~(genes that are the same but are present in different species)~~ of domestication genes in tomatoes.  
 
 ## Why groundcherry?
 
-Groundcherry was favoured due to the fact it falls under Solanaceae [^1]. This family of plants contains well researched and well-known staple crops such as potatoes, tomatoes, and peppers [^4]. The groundcherry is closer to tomatoes than any of the aforementioned model crops [^4], this permits the targeting of tomato domestication and improvement orthologs that are present in the groundcherry genome.
+Groundcherry was favoured due to the fact it falls under Solanaceae[^1]. This family of plants contains well researched and well-known staple crops such as potatoes, tomatoes, and peppers[^4]. The groundcherry is closer to tomatoes than any of the aforementioned model crops[^4], this permits the targeting of tomato domestication and improvement orthologs that are present in the groundcherry genome.
 
 
 # **Techniques, Complications and Findings**
 
 ## CC9 can be utilized in groundcherry
 
-The technical barrier to fully utilizing CC9 is the lack of efficient methodologies [^5]. This can be overcome by using a technique modelled after those methodologies utilized in tomato [^1]. Success was evaluated by targeting the ortholog of Sl-AG07, Ppr-AG07. Plants carrying the mutated Ppr-AG07 gene displayed the phenotype of narrower petals and leaves, thus proving that CC9 editing succeeded [^1].
+The technical barrier to fully utilizing CC9 is the lack of efficient methodologies[^5]. This can be overcome by using a technique modelled after those methodologies utilized in tomato[^1]. Success was evaluated by targeting the ortholog of Sl-AG07, Ppr-AG07. Plants carrying the mutated Ppr-AG07 gene displayed the phenotype of narrower petals and leaves, thus proving that CC9 editing succeeded[^1].
 
 ## Generation of Illumina whole genome (IWG) and RNA sequencing de nova assembly (RNAsda)
 
-A major problem that future researchers trying to improve orphan crops can face is the lack of a reference genome alongside the absence of genomic resources. This would mean that many orthologs of domestication and improvement genes would be missing [^1]. This paper demonstrates that by generating an IWG (a comprehensive method for analysing an entire genome) and RNAsda ~~(a method of creating a transcriptome without a reference genome)~~, you can overcome such difficulties.
+A major problem that future researchers trying to improve orphan crops can face is the lack of a reference genome alongside the absence of genomic resources. This would mean that many orthologs of domestication and improvement genes would be missing[^1]. This paper demonstrates that by generating an IWG (a comprehensive method for analysing an entire genome) and RNAsda ~~(a method of creating a transcriptome without a reference genome)~~, you can overcome such difficulties.
 
 ## Inducing mutations in genes controlling flowering
 
-Using the information provided by IWG and RNAsda, the investigators then selected the anti-florigen ~~(anti-flowering hormone)~~: Ppr-SP. However, targeting and nullifying Ppr-SP resulted in a severe phenotype that could limit fruit production [^1]. Because of this, another anti-florigen that is also responsible for day light sensitivity, Ppr-SP5G was selected. Mutations in Ppr-SP5G eliminated day light sensitivity [^1], which resulted in up to 50% higher concentration of fruits along the shoots [^1]. This has the added effect of displaying how flowering regulators can influence growth patterns.  
+Using the information provided by IWG and RNAsda, the investigators then selected the anti-florigen ~~(anti-flowering hormone)~~: Ppr-SP. However, targeting and nullifying Ppr-SP resulted in a severe phenotype that could limit fruit production[^1]. Because of this, another anti-florigen that is also responsible for day light sensitivity, Ppr-SP5G was selected. Mutations in Ppr-SP5G eliminated day light sensitivity[^1], which resulted in up to 50% higher concentration of fruits along the shoots[^1]. This has the added effect of displaying how flowering regulators can influence growth patterns.  
 
 
 ## Inducing mutations in genes responsible for fruit-size
 
-Again, using evolutionary analysis, the researchers found an ortholog of Ppr-CLV1 in the groundcherry genome. Null mutations ~~(mutations that result in loss of function of that gene)~~ were induced in Ppr-CLV1 that resulted in 24% increase of mass in groundcherry fruits [^1].  
+Again, using evolutionary analysis, the researchers found an ortholog of Ppr-CLV1 in the groundcherry genome. Null mutations ~~(mutations that result in loss of function of that gene)~~ were induced in Ppr-CLV1 that resulted in 24% increase of mass in groundcherry fruits[^1].  
 
 # Conclusion  
 
 ## The impact of this paper
 
-This study demonstrates the speed at which orphan crops can be improved and, quite possibly, be elevated to mainstream consumption and production. The gene editing technologies we have today are exceptional compared to those available a few decades ago and continue to develop at a remarkable rate [^6]. Consequently, their use should not just be limited to model crops.  
+This study demonstrates the speed at which orphan crops can be improved and, quite possibly, be elevated to mainstream consumption and production. The gene editing technologies we have today are exceptional compared to those available a few decades ago and continue to develop at a remarkable rate[^6]. Consequently, their use should not just be limited to model crops.  
 
 ## Discussion and comments
 
-There are a few issues with the study. Primarily, the importance of orphan crops is assumed throughout the paper. It does do not consider that the reason orphan crops are so genetically under-developed may be the fact that they are unable to adapt to the changing climate conditions [^7]. Therefore, this field might benefit from research that investigates potential orthologs for plant adaptation and sustainability instead of plant domestication and improvement. However, the attempt at improving the use of orphan crops provides grounds for further, more specified research. This report is a proof of concept of the potential for “genetic uplifting” present in orphan crops.  
+There are a few issues with the study. Primarily, the importance of orphan crops is assumed throughout the paper. It does do not consider that the reason orphan crops are so genetically under-developed may be the fact that they are unable to adapt to the changing climate conditions[^7]. Therefore, this field might benefit from research that investigates potential orthologs for plant adaptation and sustainability instead of plant domestication and improvement. However, the attempt at improving the use of orphan crops provides grounds for further, more specified research. This report is a proof of concept of the potential for “genetic uplifting” present in orphan crops.  
 
 # References
 

--- a/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
+++ b/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Potential For Agronomic Improvement In Orphan Crops
-description: News and Views article written about [^1]
+description: News and Views article written about a paper by Scheben et al. 
 ---
 
 # Of orphan crops and groundcherries  

--- a/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
+++ b/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
@@ -1,71 +1,63 @@
 ---
 layout: post
+title: Potential For Agronomic Improvement In Orphan Crops
+description: News and Views article written about [^1]
 ---
 
-*News and Views article written about<sup>[1]</sup>*
+# Of orphan crops and groundcherries  
 
----
-### **Of orphan crops and groundcherries**
-<br>
-<span style="font-weight:bold; font-size:18px;">What are orphan crops?</span>
-<div style="text-align: justify">  
-While gene editing technologies have been used to greatly improve staple crops such as corn, wheat, and rice<sup>[2]</sup>, there exist minor, regionally important but globally unknown crops whose potential for genetic improvement has not yet been fully explored. These “orphan crops” suffer from a range of agronomic issues that make them unsuitable for large scale production<sup>[3]</sup>.
+## What are orphan crops?
 
-This paper showcases the improvements made to the agronomic potential of the orphan crop – _Physalis pruinosa_  <span style="color:grey; font-style:italic; font-size:15px;">(groundcherry)</span> – via the genomic editing technology, CRISPR Cas-9 <span style="color:grey; font-style:italic; font-size:15px;">((Clustered regularly interspaced short palindromic repeats) (CRISPR associated protein-9 nuclease) CC9)</span>. Specifically targeting its sprawling growth habit and very strong stem abscission via orthologs <span style="color:grey; font-style:italic; font-size:15px;">(genes that are the same but are present in different species)</span> of domestication genes in tomatoes.
-</div>
-<br>
-<span style="font-weight:bold; font-size:18px;">Why groundcherry?</span>
-<div style="text-align: justify">
-Groundcherry was favoured due to the fact it falls under Solanaceae<sup>[1]</sup>. This family of plants contains well researched and well-known staple crops such as potatoes, tomatoes, and peppers<sup>[4]</sup>. The groundcherry is closer to tomatoes than any of the aforementioned model crops<sup>[4]</sup>, this permits the targeting of tomato domestication and improvement orthologs that are present in the groundcherry genome.
-</div>
-<div style="page-break-after: always;"></div>
-### **Techniques, Complications and Findings**
-<br>
-<span style="font-weight:bold; font-size:18px;">CC9 can be utilized in groundcherry</span>
-<div style="text-align: justify">
-The technical barrier to fully utilizing CC9 is the lack of efficient methodologies<sup>[5]</sup>. This can be overcome by using a technique modelled after those methodologies utilized in tomato<sup>[1]</sup>. Success was evaluated by targeting the ortholog of Sl-AG07, Ppr-AG07. Plants carrying the mutated Ppr-AG07 gene displayed the phenotype of narrower petals and leaves, thus proving that CC9 editing succeeded<sup>[1]</sup>.
-</div>
-<br>
-<span style="font-weight:bold; font-size:18px;">Generation of Illumina whole genome (IWG) and RNA sequencing de nova assembly (RNAsda)</span>
-<div style="text-align: justify">
-A major problem that future researchers trying to improve orphan crops can face is the lack of a reference genome alongside the absence of genomic resources. This would mean that many orthologs of domestication and improvement genes would be missing<sup>[1]</sup>. This paper demonstrates that by generating an IWG <span style="color:grey; font-style:italic; font-size:15px;">(a comprehensive method for analysing an entire genome)</span> and RNAsda <span style="color:grey; font-style:italic; font-size:15px;">(a method of creating a transcriptome without a reference genome)</span>, you can overcome such difficulties.
-</div>
-<br>
-<span style="font-weight:bold; font-size:18px;">Inducing mutations in genes controlling flowering</span>
-<div style="text-align: justify">
-Using the information provided by IWG and RNAsda, the investigators then selected the anti-florigen <span style="color:grey; font-style:italic; font-size:15px;">(anti-flowering hormone)</span>: Ppr-SP. However, targeting and nullifying Ppr-SP resulted in a severe phenotype that could limit fruit production<sup>[1]</sup>. Because of this, another anti-florigen that is also responsible for day light sensitivity, Ppr-SP5G was selected. Mutations in Ppr-SP5G eliminated day light sensitivity<sup>[1]</sup>, which resulted in up to 50% higher concentration of fruits along the shoots<sup>[1]</sup>. This has the added effect of displaying how flowering regulators can influence growth patterns.
-</div>
-<br>
-<span style="font-weight:bold; font-size:18px;">Inducing mutations in genes responsible for fruit-size</span>
-<div style="text-align: justify">
-Again, using evolutionary analysis, the researchers found an ortholog of Ppr-CLV1 in the groundcherry genome. Null mutations <span style="color:grey; font-style:italic; font-size:15px;">(mutations that result in loss of function of that gene)</span> were induced in Ppr-CLV1 that resulted in 24% increase of mass in groundcherry fruits<sup>[1]</sup>.
-</div>
-<div style="page-break-after: always;"></div>
-### **Conclusion**
-<br>
-<span style="font-weight:bold; font-size:18px;">The impact of this paper</span>
-<div style="text-align: justify">
-This study demonstrates the speed at which orphan crops can be improved and, quite possibly, be elevated to mainstream consumption and production. The gene editing technologies we have today are exceptional compared to those available a few decades ago and continue to develop at a remarkable rate<sup>[6]</sup>. Consequently, their use should not just be limited to model crops.
-</div>
-<br>
-<span style="font-weight:bold; font-size:18px;">Discussion and comments</span>
-<div style="text-align: justify">
-There are a few issues with the study. Primarily, the importance of orphan crops is assumed throughout the paper. It does do not consider that the reason orphan crops are so genetically under-developed may be the fact that they are unable to adapt to the changing climate conditions<sup>[7]</sup>. Therefore, this field might benefit from research that investigates potential orthologs for plant adaptation and sustainability instead of plant domestication and improvement. However, the attempt at improving the use of orphan crops provides grounds for further, more specified research. This report is a proof of concept of the potential for “genetic uplifting” present in orphan crops.
-</div>
-<div style="page-break-after: always;"></div>
+While gene editing technologies have been used to greatly improve staple crops such as corn, wheat, and rice [^2], there exist minor, regionally important but globally unknown crops whose potential for genetic improvement has not yet been fully explored. These “orphan crops” suffer from a range of agronomic issues that make them unsuitable for large scale production [^3]
 
-### **References**
+This paper showcases the improvements made to the agronomic potential of the orphan crop – *Physalis pruinos*  ~~(groundcherry)~~ – via the genomic editing technology, CRISPR Cas-9 ~~((Clustered regularly interspaced short palindromic repeats) (CRISPR associated protein-9 nuclease) CC9) ~~. Specifically targeting its sprawling growth habit and very strong stem abscission via orthologs ~~(genes that are the same but are present in different species)~~ of domestication genes in tomatoes.  
 
-1. Lemmon Z, Reem N, Dalrymple J, Soyk S, Swartwood K, Rodriguez-Leal D et al. Rapid improvement of domestication traits in an orphan crop by genome editing. Nature Plants. 2018;4(10):766-770.
+## Why groundcherry?
 
-2. Scheben A, Wolter F, Batley J, Puchta H, Edwards D. Towards CRISPR/Cas crops - bringing together genomics and genome editing. New Phytologist. 2017;216(3):682-698.
+Groundcherry was favoured due to the fact it falls under Solanaceae [^1]. This family of plants contains well researched and well-known staple crops such as potatoes, tomatoes, and peppers [^4]. The groundcherry is closer to tomatoes than any of the aforementioned model crops [^4], this permits the targeting of tomato domestication and improvement orthologs that are present in the groundcherry genome.
 
-3. Bohra A, Jha U, Kishor P, Pandey S, Singh N. Genomics and molecular breeding in lesser explored pulse crops: Current trends and future opportunities. Biotechnology Advances. 2014;32(8):1410-1428.
 
-4. Särkinen T, Bohs L, Olmstead R, Knapp S. A phylogenetic framework for evolutionary study of the nightshades (Solanaceae): a dated 1000-tip tree. BMC Evolutionary Biology. 2013;13(1):214.
+# **Techniques, Complications and Findings**
 
-5. Van Eck J. Genome editing and plant transformation of solanaceous food crops. Current Opinion in Biotechnology. 2018;49:35-41.
+## CC9 can be utilized in groundcherry
 
-6. Cermak T, Curtin S, Gil-Humanes J, Čegan R, Kono T, Konečná E et al. A multi-purpose toolkit to enable advanced genome engineering in plants. The Plant Cell. 2017;29(1196–1217):tpc.00922.2016.
+The technical barrier to fully utilizing CC9 is the lack of efficient methodologies [^5]. This can be overcome by using a technique modelled after those methodologies utilized in tomato [^1]. Success was evaluated by targeting the ortholog of Sl-AG07, Ppr-AG07. Plants carrying the mutated Ppr-AG07 gene displayed the phenotype of narrower petals and leaves, thus proving that CC9 editing succeeded [^1].
 
-7. Tadele Z. Orphan crops: their importance and the urgency of improvement. Planta. 2019;250(3):677-694.
+## Generation of Illumina whole genome (IWG) and RNA sequencing de nova assembly (RNAsda)
+
+A major problem that future researchers trying to improve orphan crops can face is the lack of a reference genome alongside the absence of genomic resources. This would mean that many orthologs of domestication and improvement genes would be missing [^1]. This paper demonstrates that by generating an IWG (a comprehensive method for analysing an entire genome) and RNAsda ~~(a method of creating a transcriptome without a reference genome)~~, you can overcome such difficulties.
+
+## Inducing mutations in genes controlling flowering
+
+Using the information provided by IWG and RNAsda, the investigators then selected the anti-florigen ~~(anti-flowering hormone)~~: Ppr-SP. However, targeting and nullifying Ppr-SP resulted in a severe phenotype that could limit fruit production [^1]. Because of this, another anti-florigen that is also responsible for day light sensitivity, Ppr-SP5G was selected. Mutations in Ppr-SP5G eliminated day light sensitivity [^1], which resulted in up to 50% higher concentration of fruits along the shoots [^1]. This has the added effect of displaying how flowering regulators can influence growth patterns.  
+
+
+## Inducing mutations in genes responsible for fruit-size
+
+Again, using evolutionary analysis, the researchers found an ortholog of Ppr-CLV1 in the groundcherry genome. Null mutations ~~(mutations that result in loss of function of that gene)~~ were induced in Ppr-CLV1 that resulted in 24% increase of mass in groundcherry fruits [^1].  
+
+# Conclusion  
+
+## The impact of this paper
+
+This study demonstrates the speed at which orphan crops can be improved and, quite possibly, be elevated to mainstream consumption and production. The gene editing technologies we have today are exceptional compared to those available a few decades ago and continue to develop at a remarkable rate [^6]. Consequently, their use should not just be limited to model crops.  
+
+## Discussion and comments
+
+There are a few issues with the study. Primarily, the importance of orphan crops is assumed throughout the paper. It does do not consider that the reason orphan crops are so genetically under-developed may be the fact that they are unable to adapt to the changing climate conditions [^7]. Therefore, this field might benefit from research that investigates potential orthologs for plant adaptation and sustainability instead of plant domestication and improvement. However, the attempt at improving the use of orphan crops provides grounds for further, more specified research. This report is a proof of concept of the potential for “genetic uplifting” present in orphan crops.  
+
+# References
+
+[^1]: Lemmon Z, Reem N, Dalrymple J, Soyk S, Swartwood K, Rodriguez-Leal D et al. Rapid improvement of domestication traits in an orphan crop by genome editing. Nature Plants. 2018;4(10):766-770.
+
+[^2]: Scheben A, Wolter F, Batley J, Puchta H, Edwards D. Towards CRISPR/Cas crops - bringing together genomics and genome editing. New Phytologist. 2017;216(3):682-698.
+
+[^3]: Bohra A, Jha U, Kishor P, Pandey S, Singh N. Genomics and molecular breeding in lesser explored pulse crops: Current trends and future opportunities. Biotechnology Advances. 2014;32(8):1410-1428.
+
+[^4]: Särkinen T, Bohs L, Olmstead R, Knapp S. A phylogenetic framework for evolutionary study of the nightshades (Solanaceae): a dated 1000-tip tree. BMC Evolutionary Biology. 2013;13(1):214.
+
+[^5]: Van Eck J. Genome editing and plant transformation of solanaceous food crops. Current Opinion in Biotechnology. 2018;49:35-41.
+
+[^6]: Cermak T, Curtin S, Gil-Humanes J, Čegan R, Kono T, Konečná E et al. A multi-purpose toolkit to enable advanced genome engineering in plants. The Plant Cell. 2017;29(1196–1217):tpc.00922.2016.
+
+[^7]: Tadele Z. Orphan crops: their importance and the urgency of improvement. Planta. 2019;250(3):677-694.

--- a/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
+++ b/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Potential For Agronomic Improvement In Orphan Crops
-description: News and Views article written about a paper by Scheben et al. 
+description: News and Views article written about a paper by *Scheben et al.*
 ---
 
 # Of orphan crops and groundcherries  

--- a/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
+++ b/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Potential For Agronomic Improvement In Orphan Crops
-description: News and Views article written about a paper by *Scheben et al.* [^1]
+description: News and Views article written about a paper by *Scheben et al.*
 ---
 
 # Of orphan crops and groundcherries  

--- a/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
+++ b/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Potential For Agronomic Improvement In Orphan Crops
-description: News and Views article written about a paper by *Scheben et al.*
+description: News and Views article written about a paper by *Scheben et al.* [^1]
 ---
 
 # Of orphan crops and groundcherries  

--- a/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
+++ b/_posts/2021-04-28-Potential-for-agronomic-improvement-in-orphan-crops.md
@@ -17,7 +17,7 @@ This paper showcases the improvements made to the agronomic potential of the orp
 Groundcherry was favoured due to the fact it falls under Solanaceae[^1]. This family of plants contains well researched and well-known staple crops such as potatoes, tomatoes, and peppers[^4]. The groundcherry is closer to tomatoes than any of the aforementioned model crops[^4], this permits the targeting of tomato domestication and improvement orthologs that are present in the groundcherry genome.
 
 
-# **Techniques, Complications and Findings**
+# Techniques, Complications and Findings
 
 ## CC9 can be utilized in groundcherry
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -303,6 +303,10 @@
   p {
     text-align: justify;
   }
+
+  .post-description {
+    font-style: italic;
+  }
 }
 
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -251,6 +251,9 @@
     @include relative-font-size(2.625);
   }
 }
+.post-description {
+  font-style: italic;
+}
 
 .post-content {
   margin-bottom: $spacing-unit;
@@ -304,9 +307,6 @@
     text-align: justify;
   }
 
-  .post-description {
-    font-style: italic;
-  }
 }
 
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -255,34 +255,42 @@
 .post-content {
   margin-bottom: $spacing-unit;
 
-  h1, h2, h3 { margin-top: $spacing-unit * 2 }
-  h4, h5, h6 { margin-top: $spacing-unit }
+  // h1, h2, h3 { margin-top: $spacing-unit * 2 }
+  // h4, h5, h6 { margin-top: $spacing-unit }
 
-  h2 {
-    @include relative-font-size(1.75);
-
+  h1 {
+    @include relative-font-size(1.4);
+    font-weight: bold;
     @media screen and (min-width: $on-large) {
       @include relative-font-size(2);
     }
   }
 
+  h2 {
+    @include relative-font-size(1.2);
+    font-weight: bold;
+    @media screen and (min-width: $on-large) {
+      @include relative-font-size(1.5);
+    }
+  }
+
   h3 {
-    @include relative-font-size(1.375);
+    @include relative-font-size(1.1);
 
     @media screen and (min-width: $on-large) {
-      @include relative-font-size(1.625);
+      @include relative-font-size(1.3));
     }
   }
 
   h4 {
-    @include relative-font-size(1.25);
+    @include relative-font-size(1.08);
   }
 
   h5 {
-    @include relative-font-size(1.125);
+    @include relative-font-size(1.0625);
   }
   h6 {
-    @include relative-font-size(1.0625);
+    @include relative-font-size(1.04);
   }
 }
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -292,6 +292,17 @@
   h6 {
     @include relative-font-size(1.04);
   }
+
+  del {
+    @include relative-font-size(0.93);
+    text-decoration: none;
+    color: grey;
+    font-style: italic;
+  }
+
+  p {
+    text-align: justify;
+  }
 }
 
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -278,7 +278,7 @@
     @include relative-font-size(1.1);
 
     @media screen and (min-width: $on-large) {
-      @include relative-font-size(1.3));
+      @include relative-font-size(1.3);
     }
   }
 


### PR DESCRIPTION
Fixed up your markdown to properly seperate formatting and data.

I replaced strike-through with your special acronym format, which is a little hacky but I think of more use to you if thats how you want to do things.

I did your little subtitle as a description, you can't do foot notes in that so I've just referenced it using a different format. This probably makes more sense because if you want to do subtitles on your home page the references wouldn't make sense anyway.

The style of markdown specifically is [kramdown](https://kramdown.gettalong.org/quickref.html), which does have support for acroymns that you could use instead, but I've tried to replicate your style closely as I could.

The template engine use's [liquid](https://jekyllrb.com/docs/liquid/), so that may be of use for some of the stuff you want to do.

Hope these changes help!